### PR TITLE
Make easier supporting workload resources

### DIFF
--- a/controllers/workloadaction_sync.go
+++ b/controllers/workloadaction_sync.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
 	"net/http"
 	"net/url"
 	"reflect"
@@ -575,9 +574,6 @@ func (r *WorkloadActionReconciler) reconcileWorkloadAction(ctx context.Context, 
 		regexParsedUrlQuery.Set("use_regex", strconv.FormatBool(UseRegexDefaultValue))
 		parsedUrl.RawQuery = regexParsedUrlQuery.Encode()
 	}
-
-	// TODO DEBUG HERE ONLY
-	log.Printf("parsedURL 4: %v", parsedUrl.String())
 
 	// 5. Make the HTTP request to the RabbitMQ admin API
 	var statusCode int


### PR DESCRIPTION
**Description:**
  1. **Add patch constructor pattern:** now we correlate a workload resource with a function that return the proper patch to restart that type of workload (avoiding nested conditionals structure). This make easier adding more workload resources types in the future.
  2. **Remove unused debug log:** seriously nobody noticed this???!!!