### PR TITLE
feat: Add object to link patch and patch-type

### DIFF
--- a/controllers/workloadaction_sync.go
+++ b/controllers/workloadaction_sync.go
@@ -63,8 +63,20 @@ const (
 	ActionRestart = "restart"
 )
 
+// PatchConstructorFuncPointerReturnT represents a 'patch' and (they way it is applied)
+// returned by a PatchConstructorFuncPointerT
+// TODO Move wherever it's better than here
+type PatchConstructorFuncPointerReturnT struct {
+	// PatchType represents the type of patch to apply
+	PatchType types.PatchType
+
+	// Patch represents the patch desired to be applied
+	Patch []byte
+}
+
 // PatchConstructorFuncPointerT represents a pointer to a function for crafting a patch
-type PatchConstructorFuncPointerT func(obj *unstructured.Unstructured) ([]byte, error)
+// TODO Move wherever it's better than here
+type PatchConstructorFuncPointerT func(obj *unstructured.Unstructured) (PatchConstructorFuncPointerReturnT, error)
 
 // HttpRequestAuth represents authentication params provided to a request
 // TODO Move wherever it's better than here
@@ -296,18 +308,20 @@ func getPodTemplateAnnotations(obj *unstructured.Unstructured) (annotations []by
 
 // defaultPatchConstructor return a patch valid for core workload resources (deployments, statefulsets, daemonsets)
 // adding previously existing annotations from podTemplate
-func defaultPatchConstructor(obj *unstructured.Unstructured) (patch []byte, err error) {
+func defaultPatchConstructor(obj *unstructured.Unstructured) (patch PatchConstructorFuncPointerReturnT, err error) {
 	annotations, err := getPodTemplateAnnotations(obj)
 	if err != nil {
 		return patch, err
 	}
 
-	patch = []byte(fmt.Sprintf(`{"spec":{"template":{"metadata":{"annotations":%s}}}}`, annotations))
+	patch.Patch = []byte(fmt.Sprintf(`{"spec":{"template":{"metadata":{"annotations":%s}}}}`, annotations))
+	patch.PatchType = types.StrategicMergePatchType
+
 	return patch, err
 }
 
 // deploymentPatchConstructor return a patch for deployment resources to be used in SetWorkloadRestartAnnotation
-func deploymentPatchConstructor(obj *unstructured.Unstructured) (patch []byte, err error) {
+func deploymentPatchConstructor(obj *unstructured.Unstructured) (patch PatchConstructorFuncPointerReturnT, err error) {
 	pausedValue, found, err := unstructured.NestedBool(obj.Object, "spec", "paused")
 	if err != nil {
 		return patch, err
@@ -345,13 +359,13 @@ func (r *WorkloadActionReconciler) SetWorkloadRestartAnnotation(ctx context.Cont
 	}
 
 	// 2. Construct the patch with related function
-	patchBytes, err := patchConstructorMap[kind](obj)
+	returnedPatch, err := patchConstructorMap[kind](obj)
 	if err != nil {
 		return err
 	}
 
 	// 3. Execute the patch
-	err = r.Patch(ctx, obj, client.RawPatch(types.StrategicMergePatchType, patchBytes))
+	err = r.Patch(ctx, obj, client.RawPatch(returnedPatch.PatchType, returnedPatch.Patch))
 	if err != nil {
 		err = fmt.Errorf(WorkloadActionAnnotationPatchErrorMessage, err)
 	}

--- a/controllers/workloadaction_sync.go
+++ b/controllers/workloadaction_sync.go
@@ -63,10 +63,10 @@ const (
 	ActionRestart = "restart"
 )
 
-// PatchConstructorFuncPointerReturnT represents a 'patch' and (they way it is applied)
+// PatchConstructorPatchT represents a 'patch' and (they way it is applied)
 // returned by a PatchConstructorFuncPointerT
 // TODO Move wherever it's better than here
-type PatchConstructorFuncPointerReturnT struct {
+type PatchConstructorPatchT struct {
 	// PatchType represents the type of patch to apply
 	PatchType types.PatchType
 
@@ -76,7 +76,7 @@ type PatchConstructorFuncPointerReturnT struct {
 
 // PatchConstructorFuncPointerT represents a pointer to a function for crafting a patch
 // TODO Move wherever it's better than here
-type PatchConstructorFuncPointerT func(obj *unstructured.Unstructured) (PatchConstructorFuncPointerReturnT, error)
+type PatchConstructorFuncPointerT func(obj *unstructured.Unstructured) (PatchConstructorPatchT, error)
 
 // HttpRequestAuth represents authentication params provided to a request
 // TODO Move wherever it's better than here
@@ -308,7 +308,7 @@ func getPodTemplateAnnotations(obj *unstructured.Unstructured) (annotations []by
 
 // defaultPatchConstructor return a patch valid for core workload resources (deployments, statefulsets, daemonsets)
 // adding previously existing annotations from podTemplate
-func defaultPatchConstructor(obj *unstructured.Unstructured) (patch PatchConstructorFuncPointerReturnT, err error) {
+func defaultPatchConstructor(obj *unstructured.Unstructured) (patch PatchConstructorPatchT, err error) {
 	annotations, err := getPodTemplateAnnotations(obj)
 	if err != nil {
 		return patch, err
@@ -321,7 +321,7 @@ func defaultPatchConstructor(obj *unstructured.Unstructured) (patch PatchConstru
 }
 
 // deploymentPatchConstructor return a patch for deployment resources to be used in SetWorkloadRestartAnnotation
-func deploymentPatchConstructor(obj *unstructured.Unstructured) (patch PatchConstructorFuncPointerReturnT, err error) {
+func deploymentPatchConstructor(obj *unstructured.Unstructured) (patch PatchConstructorPatchT, err error) {
 	pausedValue, found, err := unstructured.NestedBool(obj.Object, "spec", "paused")
 	if err != nil {
 		return patch, err


### PR DESCRIPTION
**Description:**

Due to [this issue](https://github.com/prosimcorp/rabbit-stalker/issues/4) we have detected the need to improve the way the operator can be extended. This PR deeply link the needed patch to restart a workload with the way the patch is applied. This is because `StrategicMergePatch` strategy is not suitable in all use cases, for example: Argo Rollouts